### PR TITLE
Add error handler for easier debugging

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,27 +1,33 @@
 // External deps
-const fs                    = require("fs");
-const path                  = require("path");
-const yaml                  = require('js-yaml');
-const express               = require("express");
+const fs                    = require("fs")
+const path                  = require("path")
+const yaml                  = require('js-yaml')
+const express               = require("express")
+const { createWebhooksApi } = require('@octokit/webhooks')
 
 // Local deps
 const smeeClient            = require(path.join(__dirname, 'smee.js'))
 
 // Setup
-const port       = 64897;
-const app        = express();
+const port       = 64897
+const app        = express()
 const privateKey = fs.readFileSync('gh-app.pem', 'utf8')
 const config     = JSON.parse(fs.readFileSync('config.json', 'utf8'))
 
-const smee = smeeClient(config.webproxy_url, port);
-const events = smee.start();
+const smee = smeeClient(config.webproxy_url, port)
+const events = smee.start()
+
+const webhooks = new createWebhooksApi({ secret: "mysecret", path: "/webhooks" })
+app.use(webhooks.middleware)
 
 // App
-app.use(express.json())
-app.post("/webhooks", (req, res) => {
-  console.log(req.body);
-});
+
+webhooks.on(["issue_comment.created", "issues.opened", "pull_request.opened"], async (event) => {
+  const { payload } = event
+  console.log(payload)
+})
+
 
 const listener = app.listen(port, () => {
-  console.log("Your app is listening on port " + listener.address().port);
-});
+  console.log("Your app is listening on port " + listener.address().port)
+})

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,6 +27,9 @@ webhooks.on(["issue_comment.created", "issues.opened", "pull_request.opened"], a
   console.log(payload)
 })
 
+webhooks.on("error", (error) => {
+  console.log(`Error occured in "${error.event.name} handler: ${error.stack}"`);
+});
 
 const listener = app.listen(port, () => {
   console.log("Your app is listening on port " + listener.address().port)


### PR DESCRIPTION
Noticed that `webhooks.js` makes it really hard to debug problems during the workshop. Might be good to make attendees add this code before the first checkpoint